### PR TITLE
Pass image name into application as DOCKER_TAG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ LABEL maintainer="thespad"
 ENV RAILS_ENV="production" \
     NODE_ENV="production" \
     RACK_ENV="production" \
+    DOCKER_TAG=lscr.io/linuxserver/manyfold:${VERSION} \
     PORT=3214 \
     RAILS_SERVE_STATIC_FILES=true \
     APP_VERSION=${MANYFOLD_VERSION}

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -11,6 +11,7 @@ LABEL maintainer="thespad"
 ENV RAILS_ENV="production" \
     NODE_ENV="production" \
     RACK_ENV="production" \
+    DOCKER_TAG=lscr.io/linuxserver/manyfold:${VERSION} \
     PORT=3214 \
     RAILS_SERVE_STATIC_FILES=true \
     APP_VERSION=${MANYFOLD_VERSION}


### PR DESCRIPTION
The application now reports its docker image name in usage stats, using the `DOCKER_TAG` environment variable (https://github.com/manyfold3d/manyfold/pull/3213); this PR sets that env var to the Jenkins `IMAGE` build variable to get the same data for linuxserver builds.