### PR TITLE
Add imagemagick package to install list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN \
   apk add --no-cache \
     file \
     glfw \
+    imagemagick \
     libarchive \
     libstdc++ \
     mariadb-connector-c \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -20,6 +20,7 @@ RUN \
   apk add --no-cache \
     file \
     glfw \
+    imagemagick \
     libarchive \
     libstdc++ \
     mariadb-connector-c \


### PR DESCRIPTION
v0.119.0 of Manyfold will require Imagemagick binaries; this PR adds them to the package install list.