### PR TITLE
Add newly-required dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN \
   apk add --no-cache \
     assimp-dev \
     file \
+    gcompat \
     glfw \
     imagemagick \
     imagemagick-heic \


### PR DESCRIPTION
Adds:

* assimp-dev - now required because Manyfold uses the `libassimp.so`, not the `assimp` CLI tool.
* gcompat - required because of apparent upstream changes in the postgres gem