### PR TITLE
Add custom F3D and VTK alpine packages built by Manyfold project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN \
   echo "**** install manyfold F3D package ****" && \
   curl -s -o \
     /tmp/f3d.apk -L \
-    "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.4.1-r2/f3d-3.4.1-r2.x86_64.apk" && \
+    "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.5.0-r0/f3d-3.5.0-r0.x86_64.apk" && \
   apk add --no-cache --allow-untrusted /tmp/f3d.apk && \
   rm /tmp/f3d.apk && \
   echo "**** install manyfold ****" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,15 +44,14 @@ RUN \
     postgresql-dev \
     ruby-dev \
     yaml-dev && \
-  echo "**** install manyfold F3D and VTK packages ****" && \
+  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
+    vtk && \
+  echo "**** install manyfold F3D package ****" && \
   curl -s -o \
     /tmp/f3d.apk -L \
     "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.4.1-r2/f3d-3.4.1-r2.x86_64.apk" && \
-  curl -s -o \
-    /tmp/vtk.apk -L \
-    "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.4.1-r1/vtk-9.5.2-r0.x86_64.apk" && \
-  apk add --no-cache --allow-untrusted /tmp/f3d.apk /tmp/vtk.apk && \
-  rm /tmp/f3d.apk /tmp/vtk.apk && \
+  apk add --no-cache --allow-untrusted /tmp/f3d.apk && \
+  rm /tmp/f3d.apk && \
   echo "**** install manyfold ****" && \
   mkdir -p /app/www && \
   if [ -z ${MANYFOLD_VERSION+x} ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,15 @@ RUN \
     postgresql-dev \
     ruby-dev \
     yaml-dev && \
+  echo "**** install manyfold F3D and VTK packages ****" && \
+  curl -s -o \
+    /tmp/f3d.apk -L \
+    "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.4.1-r2/f3d-3.4.1-r2.x86_64.apk" && \
+  curl -s -o \
+    /tmp/vtk.apk -L \
+    "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.4.1-r1/vtk-9.5.2-r0.x86_64.apk" && \
+  apk add --no-cache --allow-untrusted /tmp/f3d.apk /tmp/vtk.apk && \
+  rm /tmp/f3d.apk /tmp/vtk.apk && \
   echo "**** install manyfold ****" && \
   mkdir -p /app/www && \
   if [ -z ${MANYFOLD_VERSION+x} ]; then \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -44,6 +44,15 @@ RUN \
     postgresql-dev \
     ruby-dev \
     yaml-dev && \
+  echo "**** install manyfold F3D and VTK packages ****" && \
+  curl -s -o \
+    /tmp/f3d.apk -L \
+    "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.4.1-r2/f3d-3.4.1-r2.aarch64.apk" && \
+  curl -s -o \
+    /tmp/vtk.apk -L \
+    "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.4.1-r1/vtk-9.5.2-r0.aarch64.apk" && \
+  apk add --no-cache --allow-untrusted /tmp/f3d.apk /tmp/vtk.apk && \
+  rm /tmp/f3d.apk /tmp/vtk.apk && \
   echo "**** install manyfold ****" && \
   mkdir -p /app/www && \
   if [ -z ${MANYFOLD_VERSION+x} ]; then \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -44,15 +44,14 @@ RUN \
     postgresql-dev \
     ruby-dev \
     yaml-dev && \
-  echo "**** install manyfold F3D and VTK packages ****" && \
+  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
+    vtk && \
+  echo "**** install manyfold F3D package ****" && \
   curl -s -o \
     /tmp/f3d.apk -L \
     "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.4.1-r2/f3d-3.4.1-r2.aarch64.apk" && \
-  curl -s -o \
-    /tmp/vtk.apk -L \
-    "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.4.1-r1/vtk-9.5.2-r0.aarch64.apk" && \
-  apk add --no-cache --allow-untrusted /tmp/f3d.apk /tmp/vtk.apk && \
-  rm /tmp/f3d.apk /tmp/vtk.apk && \
+  apk add --no-cache --allow-untrusted /tmp/f3d.apk && \
+  rm /tmp/f3d.apk && \
   echo "**** install manyfold ****" && \
   mkdir -p /app/www && \
   if [ -z ${MANYFOLD_VERSION+x} ]; then \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -49,7 +49,7 @@ RUN \
   echo "**** install manyfold F3D package ****" && \
   curl -s -o \
     /tmp/f3d.apk -L \
-    "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.4.1-r2/f3d-3.4.1-r2.aarch64.apk" && \
+    "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.5.0-r0/f3d-3.5.0-r0.aarch64.apk" && \
   apk add --no-cache --allow-untrusted /tmp/f3d.apk && \
   rm /tmp/f3d.apk && \
   echo "**** install manyfold ****" && \


### PR DESCRIPTION
Latest Manyfold code uses https://f3d.app for server-side image rendering. Because that's not yet included in Alpine, I've built my own packages which are being included in the official image (see https://github.com/manyfold3d/f3d-alpine).

I've submitted MRs to include/update the packages in Alpine proper, but obviously that takes time, so in the meantime, these packages work OK. They're built for Alpine 3.23, and if 3.24 appears before we get these into testing, I'll update them.

https://github.com/manyfold3d/manyfold/pull/5493 is the equivalent PR to this for the official images.