### PR TITLE
Update F3D build to enable STEP rendering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,15 @@ RUN \
     postgresql-dev \
     yaml-dev && \
   apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
-    vtk && \
+    vtk \
+    opencascade \
+    imath \
+    alembic-libs \
+    openexr-libopenexr && \
   echo "**** install manyfold F3D package ****" && \
   curl -s -o \
     /tmp/f3d.apk -L \
-    "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.5.0-r0/f3d-3.5.0-r0.x86_64.apk" && \
+    "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.5.0-r0-1/f3d-3.5.0-r0.x86_64.apk" && \
   apk add --no-cache --allow-untrusted /tmp/f3d.apk && \
   rm /tmp/f3d.apk && \
   echo "**** install manyfold ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -48,11 +48,15 @@ RUN \
     postgresql-dev \
     yaml-dev && \
   apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
-    vtk && \
+    vtk \
+    opencascade \
+    imath \
+    alembic-libs \
+    openexr-libopenexr && \
   echo "**** install manyfold F3D package ****" && \
   curl -s -o \
     /tmp/f3d.apk -L \
-    "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.5.0-r0/f3d-3.5.0-r0.aarch64.apk" && \
+    "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.5.0-r0-1/f3d-3.5.0-r0.aarch64.apk" && \
   apk add --no-cache --allow-untrusted /tmp/f3d.apk && \
   rm /tmp/f3d.apk && \
   echo "**** install manyfold ****" && \


### PR DESCRIPTION
This PR mirrors the change in the official images done in https://github.com/manyfold3d/manyfold/pull/6245, and intended for release soon in v0.143.0 (though it doesn't have to happen at the same time, this can merge whenever)

The packages are built by the alpine build system for https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/97593. 

Specific builds are at https://gitlab.alpinelinux.org/Floppy/aports/-/jobs/2369750 and https://gitlab.alpinelinux.org/Floppy/aports/-/jobs/2369742